### PR TITLE
R interface fix

### DIFF
--- a/src/RPerlInit.c
+++ b/src/RPerlInit.c
@@ -275,7 +275,7 @@ PerlExtensionInit
 getPerlExtensionRoutine(USER_OBJECT_ rsExtensions)
 {
 #ifdef _R_
- void* R_FindSymbol(char const *, char const *);
+// void* R_FindSymbol(char const *, char const *);
 #endif
  PerlExtensionInit lxs_init = NULL;
 
@@ -284,7 +284,7 @@ getPerlExtensionRoutine(USER_OBJECT_ rsExtensions)
      /* */
     
 #ifdef _R_
-   lxs_init = (PerlExtensionInit) R_FindSymbol(CHAR_DEREF(STRING_ELT(rsExtensions,0)), GET_LENGTH(rsExtensions) > 1 ? CHAR_DEREF(STRING_ELT(rsExtensions,1)) : NULL);
+   lxs_init = (PerlExtensionInit) R_FindSymbol(CHAR_DEREF(STRING_ELT(rsExtensions,0)), GET_LENGTH(rsExtensions) > 1 ? CHAR_DEREF(STRING_ELT(rsExtensions,1)) : NULL, 0);
 #else
     lxs_init = (PerlExtensionInit) dlsym(NULL, CHAR_DEREF(STRING_ELT(rsExtensions,0)));
 #endif    


### PR DESCRIPTION
Hi - FYI I had to make this change to build with the R version (3.6.0) that comes along with CentOS 7. The package was also pretty fiddly about installing into the default R library; I had to pre-set the LD_LIBRARY path to an external path and install to that external path to make it go. I also had to create an empty vars.mk:

```mkdir -p /usr/lib64/R/library/RSPerl
mkdir -p /usr/lib64/R/share/make/
touch /usr/lib64/R/share/make/vars.mk
mkdir /opt/R
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/R/RSPerl/libs

git clone https://github.com/BV-BRC/RSPerl.git
cd RSPerl
R CMD INSTALL . --configure-args='--with-perl-lib= --with-in-perl'  -l /opt/R
```

Thank you for all the work you've done keeping the package up to date.

Bob